### PR TITLE
Enable individual links per item

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A configuration file must contain the following properties:
 * `file` - Path to an XML file that will host the RSS feed (likely under your webroot somewhere so an RSS reader can access it).
 * `title` - Template for the contents of the `<title>` for a single item in the RSS feed.  If this template contains any `%variables%`, they are replaced with the corresponding XPath matches from `[vars]`.
 * `description` - Same as above, but for the `<description>` tag.
+* `link` - Same as above, but optional and for the `<link>` tag. If this is not specified, the (global) `url` will be used.
 * `context` - An (optional) XPath expression to select a context node for any following expressions under `[vars]` below.  Use this to avoid repetition of the same search prefix in multiple variables.  See Examples.
 * `[vars]` - Any number of XPath expressions that will be used to scrape content from the page at `url`.  If the name of the var is `foo`, then it will be usable in the `title` and `description` fields as `%foo%`.  The only mandatory var is `guid`.
 

--- a/xpath2rss.php
+++ b/xpath2rss.php
@@ -130,7 +130,7 @@ class XPath2RSS {
 	 * @param $titleTemplate Template for title-tag
 	 * @param $descrTemplate Template for description-tag
 	 */
-	public function scrape(array $vars, $context, $feedURL, $titleTemplate, $descrTemplate) {
+	public function scrape(array $vars, $context, $feedURL, $linkTemplate, $titleTemplate, $descrTemplate) {
 
 		if (empty($vars['guid']))
 			throw new Exception("A var called 'guid' must always be defined", self::EXC_HARD);
@@ -143,13 +143,16 @@ class XPath2RSS {
 		if (isset($this->db[$repl['%guid%']]))
 			return; // we have already seen this item
 
-		$feedURL       = htmlspecialchars($feedURL);
+		if(!empty($linkTemplate))
+			$feedLink = htmlspecialchars(str_replace(array_keys($repl), array_values($repl), $linkTemplate));
+		else
+			$feedLink = htmlspecialchars($feedURL);
 		$titleTemplate = htmlspecialchars(str_replace(array_keys($repl), array_values($repl), $titleTemplate));
 		$descrTemplate = htmlspecialchars(str_replace(array_keys($repl), array_values($repl), $descrTemplate));
 
 		$this->db[$repl['%guid%']] = "<item>
 					<title>$titleTemplate</title>
-					<link>$feedURL</link>
+					<link>$feedLink</link>
 					<guid isPermaLink=\"false\">{$repl['%guid%']}</guid>
 					<pubDate>" . date(DATE_RFC822) . "</pubDate>
 					<description>$descrTemplate</description>
@@ -245,6 +248,9 @@ class XPath2RSS {
 		if (empty($ini['context']))
 			$ini['context'] = null;
 
+		if (empty($ini['link']))
+			$ini['link'] = null;
+
 		return $ini;
 
 	}
@@ -276,7 +282,7 @@ if (
 
 		$w->loadRSS($conf['file']);
 		$w->loadHTML($conf['url']);
-		$w->scrape($conf['vars'], $conf['context'], $conf['url'], $conf['title'], $conf['description']);
+		$w->scrape($conf['vars'], $conf['context'], $conf['url'], $conf['link'], $conf['title'], $conf['description']);
 		$w->writeRSS($conf['file'], $conf['feed'], $conf['url']);
 
 	} catch (Exception $e) {
@@ -327,7 +333,7 @@ if (
 
 	$w->loadRSS($conf['file']);
 	$w->loadHTML($conf['url']);
-	$w->scrape($conf['vars'], $conf['context'], $conf['url'], $conf['title'], $conf['description']);
+	$w->scrape($conf['vars'], $conf['context'], $conf['url'], $conf['link'], $conf['title'], $conf['description']);
 
 	echo $w->getRSS($conf['feed'], $conf['url']);
 

--- a/xpath2rss.php
+++ b/xpath2rss.php
@@ -154,7 +154,7 @@ class XPath2RSS {
 					<title>$titleTemplate</title>
 					<link>$feedLink</link>
 					<guid isPermaLink=\"false\">{$repl['%guid%']}</guid>
-					<pubDate>" . date(DATE_RFC822) . "</pubDate>
+					<pubDate>" . date(DATE_RSS) . "</pubDate>
 					<description>$descrTemplate</description>
 				</item>";
 


### PR DESCRIPTION
This adds the `link` configuration item which can be used to generate different links for the feed items. I've also changed the date format to `DATE_RSS` because feedvalidator.org was complaining :)
